### PR TITLE
Enhancements: recursive merging, avoiding facts cache, safety checks, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,62 @@ merged_ports:
 A note about `dedup`:
   * It has no effect when the merged vars are dictionaries.
 
+### Recursive merging ###
+
+When dealing with complex data structures, you may want to do a deep (recursive) merge.
+
+Suppose you have variables that define lists of users to add and select who should have admin privileges:
+
+```yaml
+users__someenvironment_users__to_merge:
+  users:
+    - bob
+    - henry
+  admins:
+    - bob
+```
+
+and
+
+```yaml
+users__somedatacenter_users__to_merge:
+  users:
+    - sally
+    - jane
+  admins:
+    - sally
+```
+
+You can request a recursive merge with:
+
+```yaml
+name: Merge user vars
+merge_vars:
+  suffix_to_merge: users__to_merge
+  merged_var_name: merged_users
+  expected_type: 'dict'
+  recursive_dict_merge: True
+```
+
+and get:
+
+```yaml
+merged_users:
+  users:
+    - bob
+    - henry
+    - sally
+    - jane
+  admins:
+    - bob
+    - sally
+```
+
+When merging dictionaries and the same key exists in both, the recursive merge checks the type of the value:
+* if the entry value is a list, it merges the values as lists (merge_list)
+* if the entry value is a dict, it merges the values (recursively) as dicts (merge_dict)
+* any other values: just replace (use last)
+
 ## Verbosity
 
 Running ansible-playbook with `-v` will cause this plugin to output the order in

--- a/README.md
+++ b/README.md
@@ -272,6 +272,17 @@ When merging dictionaries and the same key exists in both, the recursive merge c
 * if the entry value is a dict, it merges the values (recursively) as dicts (merge_dict)
 * any other values: just replace (use last)
 
+### Module options ###
+
+| parameter | required | default | choices | comments |
+| --------- | -------- | ------- | ------- | -------- |
+| suffix_to_merge | yes |        |         | Suffix of variables to merge.  Must end with `__to_merge`. |
+| merged_var_name | yes |        | <identifier> | Name of the target variable. |
+| expected_type | yes |          | dict, list | Expected type of the merged variable (one of dict or list) |
+| dedup     | no       | yes     | yes / no | Whether to remove duplicates from lists (arrays) after merging. |
+| cacheable | no       | no      | yes / no | If set to `yes`, the merged variable will be stored in the facts cache |
+| recursive_dict_merge | no | no | yes / no | Whether to do deep (recursive) merging of dictionaries, or just merge only at top level and replace values |
+
 ## Verbosity
 
 Running ansible-playbook with `-v` will cause this plugin to output the order in

--- a/examples/merge_recursive_playbook.yml
+++ b/examples/merge_recursive_playbook.yml
@@ -1,0 +1,26 @@
+- name: Example of recursively merging dicts
+  hosts: localhost
+  gather_facts: false  # Speed up the example
+  vars: # Note that these could be definied anywhere in inventory
+    group1_users__to_merge:
+        users:
+          - bob
+          - henry
+        admins:
+          - bob
+    group2_users__to_merge:
+      users:
+        - sally
+        - jane
+      admins:
+        - sally
+  tasks:
+    - name: Merge users vars
+      merge_vars:
+        suffix_to_merge: users__to_merge
+        merged_var_name: merged_users
+        expected_type: dict
+        recursive_dict_merge: yes
+
+    - debug:
+        var: merged_users

--- a/merge_vars.py
+++ b/merge_vars.py
@@ -32,6 +32,7 @@ class ActionModule(ActionBase):
         merged_var_name = self._task.args.get('merged_var_name', '')
         dedup = self._task.args.get('dedup', True)
         expected_type = self._task.args.get('expected_type')
+        cacheable = bool(self._task.args.get('cacheable', False))
         all_keys = task_vars.keys()
 
         # Validate args
@@ -73,6 +74,7 @@ class ActionModule(ActionBase):
         merged = self._templar.template(merged)
         return {
             'ansible_facts': {merged_var_name: merged},
+            'ansible_facts_cacheable': cacheable,
             'changed': False,
         }
 

--- a/merge_vars.py
+++ b/merge_vars.py
@@ -39,6 +39,8 @@ class ActionModule(ActionBase):
         # Validate args
         if expected_type not in ['dict', 'list']:
             raise AnsibleError("expected_type must be set ('dict' or 'list').")
+        if not merged_var_name:
+            raise AnsibleError("merged_var_name must be set")
         if not suffix_to_merge.endswith('__to_merge'):
             raise AnsibleError("Merge suffix must end with '__to_merge', sorry!")
         if merged_var_name in all_keys:

--- a/merge_vars.py
+++ b/merge_vars.py
@@ -93,22 +93,22 @@ def merge_dict(merge_vals, dedup, recursive_dict_merge):
     merged = {}
     for val in merge_vals:
         if not recursive_dict_merge:
-          merged.update(val)
+            merged.update(val)
         else:
-          # Recursive merging of dictionaries with overlapping keys:
-          #   LISTS: merge with merge_list
-          #   DICTS: recursively merge with merge_dict
-          #   any other types: replace (same as usual behaviour)
-          for key in val.keys():
-            if not key in merged:
-              # first hit of the value - just assign
-              merged[key]=val[key]
-            elif isinstance(merged[key], list):
-              merged[key]=merge_list([merged[key], val[key]], dedup)
-            elif isinstance(merged[key], dict):
-              merged[key]=merge_dict([merged[key], val[key]], dedup, recursive_dict_merge)
-            else:
-              merged[key]=val[key]
+            # Recursive merging of dictionaries with overlapping keys:
+            #   LISTS: merge with merge_list
+            #   DICTS: recursively merge with merge_dict
+            #   any other types: replace (same as usual behaviour)
+            for key in val.keys():
+                if not key in merged:
+                    # first hit of the value - just assign
+                    merged[key] = val[key]
+                elif isinstance(merged[key], list):
+                    merged[key] = merge_list([merged[key], val[key]], dedup)
+                elif isinstance(merged[key], dict):
+                    merged[key] = merge_dict([merged[key], val[key]], dedup, recursive_dict_merge)
+                else:
+                    merged[key] = val[key]
     return merged
 
 

--- a/merge_vars.py
+++ b/merge_vars.py
@@ -7,6 +7,7 @@ An Ansible action plugin to allow explicit merging of dict and list facts.
 
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
+from ansible.utils.vars import isidentifier
 
 
 # Funky import dance for Ansible backwards compatitility (not sure if we
@@ -41,6 +42,8 @@ class ActionModule(ActionBase):
             raise AnsibleError("expected_type must be set ('dict' or 'list').")
         if not merged_var_name:
             raise AnsibleError("merged_var_name must be set")
+        if not isidentifier(merged_var_name):
+            raise AnsibleError("merged_var_name '%s' is not a valid identifier" % merged_var_name)
         if not suffix_to_merge.endswith('__to_merge'):
             raise AnsibleError("Merge suffix must end with '__to_merge', sorry!")
         if merged_var_name in all_keys:


### PR DESCRIPTION
Hi,

Thanks a lot for creating this module - we find it highly useful.

When I was evaluating how the module would fit our use case, I've realized I'd need to extend it with support for recursive merging.  Our variable to merge is a complex structure: dictonary where values are arrays that need to be merged.  I think this feature might be useful, so I'm offering to share it in this PR.

In addition to that:
* I have fixed an issue where the merged variable was stored (permanently) in the facts cache.  This would also trigger a warning about overwriting the variable on subsequent runs.  The original behavior can be restored with `cacheable: True` (same as for `set_fact` module).
* I have added some safety checks for the merged_var_name parameter.
* And I have added documentation for the recursive merging
* And a table of options, in the same style as Ansible modules are documented.

Hope this is useful and can be merged - please let me know if you have any concerns with the PR.

Cheers,
Vlad