### PR TITLE
idempotence: sort vars before merging

### DIFF
--- a/ansible_merge_vars.py
+++ b/ansible_merge_vars.py
@@ -52,8 +52,8 @@ class ActionModule(ActionBase):
             display.v("The contents of {} are: {}".format(
                 merged_var_name, task_vars[merged_var_name]))
 
-        keys = [key for key in task_vars.keys()
-                if key.endswith(suffix_to_merge)]
+        keys = sorted([key for key in task_vars.keys()
+                if key.endswith(suffix_to_merge)])
 
         display.v("Merging vars in this order: {}".format(keys))
 
@@ -100,7 +100,7 @@ def merge_dict(merge_vals, dedup, recursive_dict_merge):
             #   LISTS: merge with merge_list
             #   DICTS: recursively merge with merge_dict
             #   any other types: replace (same as usual behaviour)
-            for key in val.keys():
+            for key in sorted(val.keys()):
                 if not key in merged:
                     # first hit of the value - just assign
                     merged[key] = val[key]

--- a/ansible_merge_vars.py
+++ b/ansible_merge_vars.py
@@ -100,7 +100,7 @@ def merge_dict(merge_vals, dedup, recursive_dict_merge):
             #   LISTS: merge with merge_list
             #   DICTS: recursively merge with merge_dict
             #   any other types: replace (same as usual behaviour)
-            for key in sorted(val.keys()):
+            for key in val.keys():
                 if not key in merged:
                     # first hit of the value - just assign
                     merged[key] = val[key]


### PR DESCRIPTION
Python dicts are unordered.  And we get the list of variables to merge from a dict - so in arbitrary order.

That can have effect on the merged variables - and can produce spurious changes
on subsequent runs of the same playbook with the same input variables.
(E.g., when merging a dict of lists, the entries in the inner lists could be ordered
in different ways depending on the order in which the variables were merged)

This can get worked around by playbooks using this module by sorting the lists
before using them ... but that is sub-optimal.

Improve the situation by sorting the list of variable names before merging.

And, in recursive merging, also sort the keys of any dict being merged.